### PR TITLE
Allow Manifest build version update for single counter 

### DIFF
--- a/lib/roku_builder/manifest_manager.rb
+++ b/lib/roku_builder/manifest_manager.rb
@@ -17,8 +17,8 @@ module RokuBuilder
         build_version[1] = iteration
         build_version = build_version.join(".")
       else
-        #Use current date.
-        build_version = Time.now.strftime("%m%d%y")+".0001"
+        iteration = build_version[0].to_i + 1
+        build_version = iteration.to_s
       end
       self.update_manifest(root_dir: root_dir, attributes: {build_version: build_version})
       self.build_version(root_dir: root_dir)

--- a/test/roku_builder/test_files/manifest_manager_test/manifest_template_2
+++ b/test/roku_builder/test_files/manifest_manager_test/manifest_template_2
@@ -1,6 +1,6 @@
 title=Test
 major_version=1
 minor_version=0
-build_version=010101
+build_version=1
 mm_icon_focus_hd=pkg:/images/focus.png
 mm_icon_focus_sd=pkg:/images/focus.png

--- a/test/roku_builder/test_manifest_manager.rb
+++ b/test/roku_builder/test_manifest_manager.rb
@@ -14,14 +14,11 @@ class ManifestManagerTest < Minitest::Test
     FileUtils.rm(File.join(root_dir, "manifest"))
   end
 
-  def test_manifest_manager_update_missing_build_number
+  def test_manifest_manager_update_single_part_build_number
     root_dir = File.join(File.dirname(__FILE__), "test_files", "manifest_manager_test")
     FileUtils.cp(File.join(root_dir, "manifest_template_2"), File.join(root_dir, "manifest"))
-    build_version = nil
-    Time.stub(:now, Time.new(2001, 02, 01)) do
-      build_version = RokuBuilder::ManifestManager.update_build(root_dir: root_dir)
-    end
-    assert_equal "020101.0001", build_version
+    build_version = RokuBuilder::ManifestManager.update_build(root_dir: root_dir)
+    assert_equal "2", build_version
     FileUtils.rm(File.join(root_dir, "manifest"))
   end
 


### PR DESCRIPTION
With this change if the manifest has two parts it follows the original format date+build, if only one number is there it will increment only it.