### PR TITLE
Fixed #15 and #19 - Fixed screenshot file corrupted on Windows and added support for PNG 

### DIFF
--- a/lib/roku_builder/inspector.rb
+++ b/lib/roku_builder/inspector.rb
@@ -63,8 +63,7 @@ module RokuBuilder
       path = path[1]
       unless out_file
         out_file = /time=([^"]*)">/.match(response.body)
-		    out_ext = /dev.([^"]*)\?/.match(response.body)
-        out_file = "dev_#{out_file[1]}.#{out_ext[1]}" if out_file
+        out_file = "dev_#{out_file[1]}.jpg" if out_file
       end
 
       conn = simple_connection

--- a/lib/roku_builder/inspector.rb
+++ b/lib/roku_builder/inspector.rb
@@ -63,7 +63,8 @@ module RokuBuilder
       path = path[1]
       unless out_file
         out_file = /time=([^"]*)">/.match(response.body)
-        out_file = "dev_#{out_file[1]}.jpg" if out_file
+        out_ext = /dev.([^"]*)\?/.match(response.body)
+        out_file = "dev_#{out_file[1]}.#{out_ext[1]}" if out_file
       end
 
       conn = simple_connection

--- a/lib/roku_builder/inspector.rb
+++ b/lib/roku_builder/inspector.rb
@@ -70,7 +70,7 @@ module RokuBuilder
 
       response = conn.get path
 
-      File.open(File.join(out_folder, out_file), "w") do |io|
+      File.open(File.join(out_folder, out_file), "wb") do |io|
         io.write(response.body)
       end
       @logger.info "Screen captured to #{File.join(out_folder, out_file)}"

--- a/lib/roku_builder/inspector.rb
+++ b/lib/roku_builder/inspector.rb
@@ -63,7 +63,8 @@ module RokuBuilder
       path = path[1]
       unless out_file
         out_file = /time=([^"]*)">/.match(response.body)
-        out_file = "dev_#{out_file[1]}.jpg" if out_file
+		    out_ext = /dev.([^"]*)\?/.match(response.body)
+        out_file = "dev_#{out_file[1]}.#{out_ext[1]}" if out_file
       end
 
       conn = simple_connection


### PR DESCRIPTION
The screenshot file was being created without the binary flag