### PR TITLE
Added ability to filter help by plugin name

### DIFF
--- a/lib/roku_builder/plugins/core.rb
+++ b/lib/roku_builder/plugins/core.rb
@@ -77,7 +77,6 @@ module RokuBuilder
       end
       parser.on("-h", "--help [PLUGIN]", "Show help") do |h|
         plugin = self.get_plugin_by_name(h)
-        puts plugin
         if nil == plugin
           puts parser
         else

--- a/lib/roku_builder/plugins/core.rb
+++ b/lib/roku_builder/plugins/core.rb
@@ -116,7 +116,6 @@ module RokuBuilder
 
     def self.get_help_text(parser:, options:, plugin_name:)
       plugin = self.get_plugin_by_name(plugin_name)
-      puts parser
       if nil == plugin
         return parser.to_s
       else

--- a/lib/roku_builder/plugins/core.rb
+++ b/lib/roku_builder/plugins/core.rb
@@ -76,16 +76,8 @@ module RokuBuilder
         options[:debug] = true
       end
       parser.on("-h", "--help [PLUGIN]", "Show help") do |h|
-        plugin = self.get_plugin_by_name(h)
-        if nil == plugin
-          puts parser
-        else
-          pluginParser = OptionParser.new
-          pluginParser.separator ""
-          pluginParser.separator "Options for #{plugin}:"
-          plugin.parse_options(parser: pluginParser, options: options)
-          puts pluginParser
-        end
+        help_text = self.get_help_text(parser: parser, options: options, plugin_name: h)
+        puts help_text
         exit
       end
       parser.on("-v", "--version", "Show version") do
@@ -122,12 +114,26 @@ module RokuBuilder
       Stager.new(config: @config, options: options).unstage
     end
 
+    def self.get_help_text(parser:, options:, plugin_name:)
+      plugin = self.get_plugin_by_name(plugin_name)
+      puts parser
+      if nil == plugin
+        return parser.to_s
+      else
+        pluginParser = OptionParser.new
+        pluginParser.separator ""
+        pluginParser.separator "Options for #{plugin}:"
+        plugin.parse_options(parser: pluginParser, options: options)
+        return pluginParser.to_s
+      end
+    end
+
     def self.get_plugin_by_name(name)
       if name.nil?
         return nil
       end
       pluginIndex = RokuBuilder.plugins.map{|pluginClass| pluginClass.name.split('::').last().downcase}.index(name.downcase)
-     if !pluginIndex.nil?
+      if !pluginIndex.nil?
         plugin = RokuBuilder.plugins[pluginIndex]
         return plugin
       end

--- a/lib/roku_builder/plugins/core.rb
+++ b/lib/roku_builder/plugins/core.rb
@@ -75,8 +75,18 @@ module RokuBuilder
       parser.on("--debug", "Print Debug messages") do
         options[:debug] = true
       end
-      parser.on("-h", "--help", "Show this message") do
-        puts parser
+      parser.on("-h", "--help [PLUGIN]", "Show help") do |h|
+        plugin = self.get_plugin_by_name(h)
+        puts plugin
+        if nil == plugin
+          puts parser
+        else
+          pluginParser = OptionParser.new
+          pluginParser.separator ""
+          pluginParser.separator "Options for #{plugin}:"
+          plugin.parse_options(parser: pluginParser, options: options)
+          puts pluginParser
+        end
         exit
       end
       parser.on("-v", "--version", "Show version") do
@@ -111,6 +121,17 @@ module RokuBuilder
     end
     def dounstage(options:)
       Stager.new(config: @config, options: options).unstage
+    end
+
+    def self.get_plugin_by_name(name)
+      if name.nil?
+        return nil
+      end
+      pluginIndex = RokuBuilder.plugins.map{|pluginClass| pluginClass.name.split('::').last().downcase}.index(name.downcase)
+     if !pluginIndex.nil?
+        plugin = RokuBuilder.plugins[pluginIndex]
+        return plugin
+      end
     end
   end
   RokuBuilder.register_plugin(Core)

--- a/test/roku_builder/plugins/test_core.rb
+++ b/test/roku_builder/plugins/test_core.rb
@@ -108,6 +108,25 @@ module RokuBuilder
         core.dounstage(options: options)
       end
     end
+    def test_core_help
+      parser = OptionParser.new
+      options = {}
+      help_text = Core.get_help_text(parser: parser, options: options, plugin_name: nil)
+      assert help_text
+    end
+    def test_core_help_plugin
+      parser = OptionParser.new
+      options = {}
+      help_text = Core.get_help_text(parser: parser, options: options, plugin_name: "Loader")
+      assert help_text
+    end
+    def test_core_get_plugin_by_name
+      parser = OptionParser.new
+      options = {}
+      plugin_name = Core.get_plugin_by_name("loader")
+      assert plugin_name
+      assert_match "RokuBuilder::Loader", plugin_name.to_s
+    end
   end
 end
 


### PR DESCRIPTION
Can do `roku --help pluginName` to just get the help for a particular plugin

e.g.

```
% roku --help loader
Usage: roku [options]

Options for RokuBuilder::Loader:
Commands:
    -l, --sideload                   Sideload an app
    -d, --delete                     Delete the currently sideloaded app
    -b, --build                      Build a zip to be sideloaded
        --squash                     Convert currently sideloaded application to squashfs
Options:
    -x, --exclude                    Apply exclude config to sideload
        --remote-debug               Sideload will enable remote debug
```
