### PR TITLE
Added capability to save common deeplinks in a config file

### DIFF
--- a/lib/roku_builder/config_parser.rb
+++ b/lib/roku_builder/config_parser.rb
@@ -31,6 +31,7 @@ module RokuBuilder
       setup_root_dir
       setup_input_mappings
       setup_console_log
+      setup_deeplinks
     end
 
     def process_in_argument
@@ -222,5 +223,10 @@ module RokuBuilder
     def setup_console_log
       @parsed[:console_log] = @config[:console_log]
     end
+
+    def setup_deeplinks
+      @parsed[:deeplinks] = @config[:deeplinks]
+    end
+
   end
 end

--- a/lib/roku_builder/plugins/linker.rb
+++ b/lib/roku_builder/plugins/linker.rb
@@ -16,10 +16,10 @@ module RokuBuilder
 
     def self.parse_options(parser:,  options:)
       parser.separator "Commands:"
-      parser.on("-o", "--deeplink OPTIONS", "Launch and Deeplink into app. Define options as keypairs. (eg. a:b, c:d,e:f)") do |o|
+      parser.on("-o", "--deeplink OPTIONS", "Launch and Deeplink into app. Define options as keypairs (eg. \"a:b, c:d,e:f\") or name (eg. \"name\"). To use named deeplinks, including them in your config file: \"deeplinks\": { \"name\": \"a:b, c:d, e:f\" }") do |o|
         options[:deeplink] = o
       end
-      parser.on("-i", "--input OPTIONS", "Deeplink into app. Define options as keypairs. (eg. a:b, c:d,e:f)") do |o|
+      parser.on("-i", "--input OPTIONS", "Deeplink into app. Define options as keypairs (eg. \"a:b, c:d,e:f\") or name (eg. \"name\"). To use named deeplinks, including them in your config file: \"deeplinks\": { \"name\": \"a:b, c:d, e:f\" }") do |o|
         options[:input] = o
       end
       parser.on("-A", "--app-list", "List currently installed apps") do
@@ -80,6 +80,13 @@ module RokuBuilder
         unless payload.keys.count > 0
           @logger.warn "No options sent to launched app"
         else
+          deeplinks = @config.deeplinks
+          firstKey = payload.keys.first
+          if !deeplinks.nil?
+            if !deeplinks[firstKey].nil?
+              payload = RokuBuilder.options_parse(options: deeplinks[firstKey])
+            end
+          end
           payload = parameterize(payload)
           path = "#{path}?#{payload}"
             @logger.info "Deeplink:"

--- a/lib/roku_builder/version.rb
+++ b/lib/roku_builder/version.rb
@@ -2,5 +2,5 @@
 
 module RokuBuilder
   # Version of the RokuBuilder Gem
-  VERSION = "4.29.4"
+  VERSION = "4.29.5"
 end


### PR DESCRIPTION
To use this capability, add a section to your config file:
"deeplinks": {
  "name": "a:b, c:d, e:f",
  "debug": "mediaType:screen, contentId:debug"
}

Then you can use one of the deeplink commands without needing to type the long set of options:
roku -i "debug"